### PR TITLE
Adding ignore for pip 25.2 pip-audit vulnerability, removing stale ones

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -55,12 +55,6 @@ jobs:
         uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266
         with:
           virtual-environment: .venv/
-          # GHSA-887c-mr87-cxwp torch vulnerability without a fix yet
-          # PYSEC-2025-41, PYSEC-2024-259: These ignores are temporary. Synthcity needs python below or at 2.4 and
-          # these vulnerabilities exist until 2.5. However, we'll be removing the Synthcity dependency in follow up.
-          # So we'll be able to upgrade torch and drop these there.
+          # GHSA-4xh5-x5gv-qwph: This is a vulnerability in pip 25.2 that has no fix version yet
           ignore-vulns: |
-            GHSA-887c-mr87-cxwp
-            GHSA-3749-ghw9-m3mg
-            PYSEC-2025-41
-            PYSEC-2024-259
+            GHSA-4xh5-x5gv-qwph


### PR DESCRIPTION
# PR Type
Fix

# Short Description

Clickup Ticket(s): NA

Adding ignore for pip 25.2 pip-audit vulnerability, removing stale ones now that we have upgraded to torch 2.8.0.

# Tests Added

NA